### PR TITLE
Don't remove top level node_modules from emscripten package

### DIFF
--- a/bin/deploy_emscripten_llvm.py
+++ b/bin/deploy_emscripten_llvm.py
@@ -459,16 +459,7 @@ def deploy_emscripten(llvm_source_dir, emscripten_source_dir, emscripten_output_
   print 'Zipping up "' + zip_filename + '"'
   if os.path.isfile(zip_filename): os.remove(zip_filename)
 
-  # We want to ignore the root '/node_modules' directory from the zip, but there are other node_modules directories in the Emscripten tree
-  # which do need to get in to the generated zip. The simplest way seems to be to temporarily rename the root node_modules directory to
-  # a different name, which will be ignored during zipping.
-  if os.path.isdir(os.path.join(emscripten_output_dir, 'node_modules')):
-    os.rename(os.path.join(emscripten_output_dir, 'node_modules'), os.path.join(emscripten_output_dir, 'node_modules_ignore'))
-  try:
-    zip_up_directory(emscripten_output_dir, zip_filename, ['.git', 'node_modules_ignore', 'third_party/lzma.js/', '*.pyc'])
-  finally:
-    if os.path.isdir(os.path.join(emscripten_output_dir, 'node_modules_ignore')):
-      os.rename(os.path.join(emscripten_output_dir, 'node_modules_ignore'), os.path.join(emscripten_output_dir, 'node_modules'))
+  zip_up_directory(emscripten_output_dir, zip_filename, ['.git', 'third_party/lzma.js/', '*.pyc'])
 
   print zip_filename + ': ' + str(os.path.getsize(zip_filename)) + ' bytes.'
 


### PR DESCRIPTION
That plan is to start using this top level node_modules
directory for any/all node module dependencies.

Ideally the SDK version would with pre-downloaded node_modules
so that users don't need to download stuff on first use.

See https://github.com/kripken/emscripten/issues/5774
See https://github.com/kripken/emscripten/issues/7538